### PR TITLE
Add an issue form for installation results

### DIFF
--- a/.github/ISSUE_TEMPLATE/catalog-problem.yml
+++ b/.github/ISSUE_TEMPLATE/catalog-problem.yml
@@ -51,6 +51,13 @@ body:
       description: For recipe failures, include the OS, architecture, Docker and Compose versions, and sanitized logs.
       render: text
 
+  - type: textarea
+    id: context
+    attributes:
+      label: Recipe context
+      description: The application page fills this in for you. Leave it as it arrived.
+      render: text
+
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/installation-result.yml
+++ b/.github/ISSUE_TEMPLATE/installation-result.yml
@@ -1,0 +1,100 @@
+name: Share an installation result
+description: Report how a recipe worked on your own server, whether it succeeded or failed.
+title: "[Result]: "
+labels:
+  - installation-result
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A result is useful either way: a recipe that worked tells us the instructions hold, and one that did not tells us where they break. Do not include passwords, tokens, private keys, personal data, or vulnerability details. Use private vulnerability reporting for security issues.
+
+  - type: input
+    id: application
+    attributes:
+      label: Application
+      description: Enter the application name or catalog slug.
+      placeholder: uptime-kuma
+    validations:
+      required: true
+
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Outcome
+      options:
+        - Running — I reached the first login
+        - Running — but I had to deviate from the instructions
+        - Stuck partway
+        - Did not work at all
+    validations:
+      required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: How did you install it?
+      options:
+        - Generated configuration bundle (ZIP)
+        - Generated install.sh
+        - Manually, following the installation guide
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Where did you deploy it?
+      options:
+        - Local network, no domain
+        - Public server, IP address only
+        - Public server with a domain and HTTPS
+    validations:
+      required: true
+
+  - type: textarea
+    id: story
+    attributes:
+      label: What happened?
+      description: Describe what you did and, for anything short of a clean first login, the step where it went wrong and what the error said.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data
+    attributes:
+      label: Did you try backup and restore?
+      options:
+        - Both, and the restore worked
+        - Both, and the restore failed
+        - Backup only
+        - Neither
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Server
+      description: Architecture, operating system, RAM, disk, and the output of `docker compose version`. Include sanitized logs for a failure.
+      render: text
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Recipe context
+      description: The application page fills this in for you. Leave it as it arrived.
+      render: text
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I removed credentials, personal data, and other sensitive information.
+          required: true
+        - label: I ran this myself and am reporting what actually happened.
+          required: true
+        - label: I agree to follow the Code of Conduct.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,22 @@
 Contributions that improve an existing entry or add a well-researched
 self-hosted application are welcome.
 
+## Opening an issue
+
+Three forms cover what the catalog needs to hear: a catalog problem (wrong
+data, a broken recipe, documentation, an asset), an application suggestion, and
+an installation result.
+
+An installation result is worth reporting when it went well, too. A recipe is
+written and smoke-tested on a handful of machines, and a report from a
+different server is the only evidence that its instructions hold anywhere else
+— so "it worked, here is what I ran it on" is a useful issue. The application
+page on [fossary.com](https://fossary.com) prefills the recipe context for you.
+
+Security issues go through private vulnerability reporting instead, as
+described in [SECURITY.md](SECURITY.md); do not put vulnerability details in a
+public issue.
+
 ## Before opening a pull request
 
 1. Read the [application requirements](docs/app-requirements.md),


### PR DESCRIPTION
The catalog has forms for a problem and for a suggestion, but no way to say
what happened when someone actually ran a recipe — and that report is the one
piece of evidence a smoke test cannot produce, because it comes from a machine
the recipe was not written on.

`installation-result.yml` asks for the application, the outcome, how it was
installed, where it was deployed, what happened, whether backup and restore
were tried, and the server it ran on. `context` is a pre-rendered field the
application page on fossary.com fills in with the application version, the
recipe version, the catalog revision and the page URL, so a report carries the
exact recipe it is about.

Issues from the form carry the new `installation-result` label. `CONTRIBUTING.md`
now names the three forms and says plainly that a successful install is worth
reporting too.